### PR TITLE
Update v19 version for CCL

### DIFF
--- a/.github/workflows/desc-stack-latest.yml
+++ b/.github/workflows/desc-stack-latest.yml
@@ -7,12 +7,16 @@ jobs:
     name: Build on Ubuntu
     runs-on: ubuntu-18.04
     steps:
+      - name: Check Disk Space
+        run: df -h && sudo apt-get clean && df -h 
       - name: Docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username heather999 --password-stdin
       - name: checkout desc-stack
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
+      - name : Docker prune
+        run: sudo docker system prune && df -h 
       - name: do docker build
         run: docker build --no-cache -t lsstdesc/stack-jupyter:latest -f $GITHUB_WORKSPACE/Dockerfile . 
       - name: Docker push

--- a/.github/workflows/desc-stack-prod.yml
+++ b/.github/workflows/desc-stack-prod.yml
@@ -10,12 +10,16 @@ jobs:
     name: desc-stack prod
     runs-on: ubuntu-18.04
     steps:
+      - name: Check Disk Space
+        run: df -h && sudo apt-get clean && df -h 
       - name: Docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username heather999 --password-stdin
       - name: checkout desc-stack
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
+      - name : Docker prune
+        run: sudo docker system prune && df -h 
       - name: pull dev
         run: docker pull lsstdesc/stack-jupyter:dev
       - name: Docker tag prod

--- a/.github/workflows/desc-stack-release.yml
+++ b/.github/workflows/desc-stack-release.yml
@@ -9,12 +9,16 @@ jobs:
     name: desc-stack release
     runs-on: ubuntu-18.04
     steps:
+      - name: Check Disk Space
+        run: df -h && sudo apt-get clean && df -h 
       - name: Docker login
         run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username heather999 --password-stdin
       - name: checkout desc-stack
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
+      - name : Docker prune
+        run: sudo docker system prune && df -h 
       - name: Get the tag
         id: get_tag
         run: echo ::set-output name=DOCKTAG::${GITHUB_REF/refs\/tags\//}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,11 @@ RUN echo "Installing DESC requested packages" && \
                   pip install -c $LSST_STACK_DIR/require.txt healpy; \
                   pip install -c $LSST_STACK_DIR/require.txt https://bitbucket.org/yymao/helpers/get/v0.3.2.tar.gz; \
                   pip install -c $LSST_STACK_DIR/require.txt markupsafe nose; \
-                  pip install -c $LSST_STACK_DIR/require.txt parsl==0.7.2; \
+                  pip install -c $LSST_STACK_DIR/require.txt parsl; \
                   export PYMSSQL_BUILD_WITH_BUNDLED_FREEETDS=1; \
                   pip install -c $LSST_STACK_DIR/require.txt pymssql; \
                   pip install -c $LSST_STACK_DIR/require.txt tables; \
-                  pip install -c $LSST_STACK_DIR/require.txt TreeCorr==4.0.8; \
+                  pip install -c $LSST_STACK_DIR/require.txt TreeCorr; \
                   pip install -c $LSST_STACK_DIR/require.txt https://github.com/LSSTDESC/descqa/archive/v2.0.0-0.7.0.tar.gz; \
                   pip install -c $LSST_STACK_DIR/require.txt https://github.com/LSSTDESC/desc-dc2-dm-data/archive/v0.5.0.tar.gz; \
                   pip install -c $LSST_STACK_DIR/require.txt corner; \
@@ -53,7 +53,7 @@ RUN echo "Installing DESC requested packages" && \
                   conda install --no-deps -y swig; \
                   setup fftw; \
                   setup gsl; \
-                  pip install -c $LSST_STACK_DIR/require.txt pyccl==2.0.1;'
+                  pip install -c $LSST_STACK_DIR/require.txt pyccl==2.1.0;'
 
 RUN echo "Finish Installing fast3tree" && \
     /bin/bash -c 'source $LSST_STACK_DIR/loadLSST.bash; \
@@ -94,7 +94,7 @@ RUN echo "Installing GCR packages" && \
     /bin/bash -c 'source $LSST_STACK_DIR/loadLSST.bash; \
                   pip freeze > $LSST_STACK_DIR/require.txt; \
                   pip install -c $LSST_STACK_DIR/require.txt GCR==0.8.8; \
-                  pip install https://github.com/LSSTDESC/gcr-catalogs/archive/v0.15.0.tar.gz' 
+                  pip install https://github.com/LSSTDESC/gcr-catalogs/archive/v0.16.1.tar.gz' 
 
 ENV HDF5_USE_FILE_LOCKING FALSE
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,24 @@ DESC desc-stack
 Python Environment containing DMstack lsst-distrib plus DESC requested packages for use at the command line and as a Jupyter kernel
 
 Available at NERSC by setting up [DESC Kernels](https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter+at+NERSC)
+
+### Kernels
+- desc-stack: Current DM version of python with functional DMstack (lsst_distrib) + DESC requested packages
+- desc-stack-dev: Upcoming production release of desc-stack
+- desc-stack-old: Previous production version of desc-stack
+
+
+## Available on Dockerhub
+See: https://hub.docker.com/r/lsstdesc/stack-jupyter/tags
+
+
+## desc-stack Releases
+
+### Current Run2.2i Shifter Image
+lsstdesc/stack-jupyter:prod
+
+### Final Run2.1i Shifter Image 
+lsstdesc/stack-jupyter:w_2019_19-sims_w_2019_19-v15
+
+### Final Run1.2i Shifter Image 
+lsstdesc/stack-jupyter:w_2018_39-sims_2_11_1-run1.2-v14


### PR DESCRIPTION
Move to latest CCL release and allow some other packages to pick up latest releases.