### PR TITLE
Add desc-stack-release build workflow

### DIFF
--- a/.github/workflows/desc-stack-release-build.yml
+++ b/.github/workflows/desc-stack-release-build.yml
@@ -1,0 +1,67 @@
+name: desc-stack-release build
+
+on:
+  schedule:
+    - cron: '15 23 * * 6'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on Ubuntu
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false    
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Check Disk Space
+        run: df -h && sudo apt-get clean && df -h 
+      - name: Docker login
+        run: echo '${{ secrets.DOCKERHUB_ACCESSTOK }}' | docker login --username heather999 --password-stdin
+      - name: checkout desc-stack
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 1
+     
+      - name : Set release and date 
+        run: |
+          echo "LSST_TAG=v29_2_1" >> $GITHUB_ENV
+          echo "DATE_TAG=$(date "+%F")" >> $GITHUB_ENV
+     # - name: tag current weekly
+     #   run: |
+    #      docker pull lsstdesc/stack-jupyter:release-latest
+   #       docker run --rm lsstdesc/stack-jupyter:release-latest /bin/bash -c "source /opt/lsst/software/stack/loadLSST.bash"
+     #     if $?; then
+     #       echo "No functional release-latest with lsst_distrib available"
+     #     else
+     ##       docker tag lsstdesc/stack-jupyter:weekly-latest lsstdesc/stack-jupyter:weekly
+       #     docker push lsstdesc/stack-jupyter:weekly
+       #   fi
+        #continue-on-error: true
+      - name: do docker build
+        run: docker build --no-cache --build-arg LSST_TAG=${{env.LSST_TAG}} -t lsstdesc/stack-jupyter:${{env.LSST_TAG}} -f $GITHUB_WORKSPACE/Dockerfile . 
+      - name: test pyccl
+        run: docker run --rm lsstdesc/stack-jupyter:${{env.LSST_TAG}} /bin/bash -c "source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && python -c 'import pyccl'"
+      - name: Docker push
+        run: docker push lsstdesc/stack-jupyter:${{env.LSST_TAG}}
+      - name: tag versions
+        run: |
+          docker tag lsstdesc/stack-jupyter:${{env.LSST_TAG}} lsstdesc/stack-jupyter:${{env.LSST_TAG}}-${{env.DATE_TAG}}
+          docker push lsstdesc/stack-jupyter:${{env.LSST_TAG}}-${{env.DATE_TAG}}
+          docker tag lsstdesc/stack-jupyter:${{env.LSST_TAG}} lsstdesc/desc-stack:${{env.LSST_TAG}}-${{env.DATE_TAG}}
+          docker push lsstdesc/desc-stack:${{env.LSST_TAG}}-${{env.DATE_TAG}}
+          docker tag lsstdesc/stack-jupyter:${{env.LSST_TAG}} lsstdesc/desc-stack:${{env.LSST_TAG}}
+          docker push lsstdesc/desc-stack:${{env.LSST_TAG}}
+  
+       


### PR DESCRIPTION
This workflow builds the desc-stack-release on a schedule and allows manual triggering. It includes steps for disk space management, Docker login, building images, testing, and tagging.