### PR TITLE
Disable scheduled cron job in desc-stack-release build

### DIFF
--- a/.github/workflows/desc-stack-release-build.yml
+++ b/.github/workflows/desc-stack-release-build.yml
@@ -1,8 +1,8 @@
 name: desc-stack-release build
 
 on:
-  schedule:
-    - cron: '15 23 * * 6'
+  #schedule:
+  #  - cron: '15 23 * * 6'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Comment out the scheduled cron job for the release build workflow.